### PR TITLE
Remove problematic sort in m2_to_m2

### DIFF
--- a/m2_to_m2.py
+++ b/m2_to_m2.py
@@ -34,7 +34,7 @@ def main(args):
 			# Save marked up original sentence here, if required.
 			proc_orig = ""
 			# Loop through the annotators
-			for coder, coder_info in coder_dict.items():
+			for coder, coder_info in sorted(coder_dict.items()):
 				cor_sent = coder_info[0]
 				gold_edits = coder_info[1]
 				# If there is only 1 edit and it is noop, just write it.

--- a/m2_to_m2.py
+++ b/m2_to_m2.py
@@ -34,7 +34,7 @@ def main(args):
 			# Save marked up original sentence here, if required.
 			proc_orig = ""
 			# Loop through the annotators
-			for coder, coder_info in sorted(coder_dict.items()):
+			for coder, coder_info in coder_dict.items():
 				cor_sent = coder_info[0]
 				gold_edits = coder_info[1]
 				# If there is only 1 edit and it is noop, just write it.

--- a/scripts/toolbox.py
+++ b/scripts/toolbox.py
@@ -43,7 +43,7 @@ def processM2(info):
 		cor_sent = orig_sent[:]
 		gold_edits = []
 		offset = 0
-		for edit in sorted(edits):
+		for edit in edits:
 			# Do not apply noop or Um edits, but save them
 			if edit[2] in {"noop", "Um"}: 
 				gold_edits.append(edit+[-1,-1])


### PR DESCRIPTION
Remove sort that reorders multiple insertions at the same token position. Preserve original order instead of reordering tokens alphabetically.