### PR TITLE
optimize spacy tokenizing speed

### DIFF
--- a/errant/__init__.py
+++ b/errant/__init__.py
@@ -1,10 +1,21 @@
 from importlib import import_module
 import spacy
+from spacy.tokens import Doc
 from errant.annotator import Annotator
 
 # ERRANT version
 __version__ = '2.2.1'
 
+class WhitespaceTokenizer(object):
+    def __init__(self, vocab):
+        self.vocab = vocab
+
+    def __call__(self, text):
+        words = text.split(' ')
+        # All tokens 'own' a subsequent space character in this tokenizer
+        spaces = [True] * len(words)
+        return Doc(self.vocab, words=words, spaces=spaces)
+    
 # Load an ERRANT Annotator object for a given language
 def load(lang, nlp=None):
     # Make sure the language is supported
@@ -14,7 +25,7 @@ def load(lang, nlp=None):
 
     # Load spacy
     nlp = nlp or spacy.load(lang, disable=["ner"])
-
+    nlp.tokenizer = WhitespaceTokenizer(nlp.vocab)
     # Load language edit merger
     merger = import_module("errant.%s.merger" % lang)
 

--- a/errant/annotator.py
+++ b/errant/annotator.py
@@ -21,7 +21,7 @@ class Annotator:
         if tokenise:
             text = self.nlp(text)
         else:
-            text = self.nlp.tokenizer.tokens_from_list(text.split())
+            text = self.nlp.tokenizer(text)
             self.nlp.tagger(text)
             self.nlp.parser(text)
         return text


### PR DESCRIPTION
Using errant to process amount of sentences will cost lots of time. I analysis the time cost of each module  and find the calling `tokens_from_list` is the reason. So I use Whitespacetokenizer to replace it.