### PR TITLE
Open/close out_m2 correctly in parallel_to_m2.py

### DIFF
--- a/errant/commands/parallel_to_m2.py
+++ b/errant/commands/parallel_to_m2.py
@@ -8,13 +8,11 @@ def main():
     print("Loading resources...")
     # Load Errant
     annotator = errant.load("en")
-    # Open output m2 file
-    out_m2 = open(args.out, "w")
 
     print("Processing parallel files...")
     # Process an arbitrary number of files line by line simultaneously. Python 3.3+
     # See https://tinyurl.com/y4cj4gth
-    with ExitStack() as stack:
+    with open(args.out, "w") as out_m2, ExitStack() as stack:
         in_files = [stack.enter_context(open(i)) for i in [args.orig]+args.cor]
         # Process each line of all input files
         for line in zip(*in_files):


### PR DESCRIPTION
Currently out_m2 file is opened and not closed, which might lead to weird bugs. Opening with **with** should handle everything.

A side note:
I would like to wrap the main functions from parallel_to_m2.py and compare_m2.py in separate functions which are then called from the respective main.

In this way they can be run both as a script (as currently suggested in the readme), or loaded as a function from an external python script. Would you be okay with such a pull request?