### PR TITLE
Development of API-based errant_compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ It provides API-based errant_compare.
 ```py
 import errant
 import pprint
-annotator = errant.load('en')
 orig_raw = ['This are gramamtical sentence .']
 cor_raw = ['This is grammatical sentence .']
 # refs_raw: List[List[str]] = (num_annotation, num_sents)
@@ -197,7 +196,7 @@ refs_raw = [
     ['This is a grammatical sentence .'],
     ['These are grammatical sentences .']
 ]
-entire_score, etype_score = errant.compare_from_raw(
+overall_score, etype_score = errant.compare_from_raw(
     orig=orig_raw,
     cor=cor_raw,
     refs=refs_raw,
@@ -206,18 +205,18 @@ entire_score, etype_score = errant.compare_from_raw(
     single=False,
     multi=False,
     detection=False,
-    cat_filter=[]
+    filt=[]
 )
 
 print('=== etype score ===')
 pprint.pprint(etype_score, width=100)
-print('=== entire score ===')
-print(entire_score)
+print('=== overall score ===')
+print(overall_score)
 """
 === etype score ===
 {'M': {'f_0.5': 0.0, 'fn': 1, 'fp': 0, 'p': 1.0, 'r': 0.0, 'tp': 0},
  'R': {'f_0.5': 1.0, 'fn': 0, 'fp': 0, 'p': 1.0, 'r': 1.0, 'tp': 2}}
-=== entire score ===
+=== overall score ===
 {'tp': 2, 'fp': 0, 'fn': 1, 'p': 1.0, 'r': 0.6667, 'f_0.5': 0.9091}
 """
 ```
@@ -248,7 +247,7 @@ entire_score, etype_score = errant.compare_from_edits(
     single=False,
     multi=False,
     detection=False,
-    cat_filter=[]
+    filt=[]
 )
 
 print('=== etype score ===')

--- a/README.md
+++ b/README.md
@@ -181,6 +181,82 @@ edit = annotator.import_edit(orig, cor, edit)
 print(edit.to_m2())
 ```
 
+### API-based errant_compare
+
+It provides API-based errant_compare.
+
+- From raw text
+```py
+import errant
+import pprint
+annotator = errant.load('en')
+orig_raw = ['This are gramamtical sentence .']
+cor_raw = ['This is grammatical sentence .']
+# refs_raw: List[List[str]] = (num_annotation, num_sents)
+refs_raw = [
+    ['This is a grammatical sentence .'],
+    ['These are grammatical sentences .']
+]
+entire_score, etype_score = errant.compare_from_raw(
+    orig=orig_raw,
+    cor=cor_raw,
+    refs=refs_raw,
+    beta=0.5,
+    cat=1,
+    single=False,
+    multi=False,
+    detection=False,
+    cat_filter=[]
+)
+
+print('=== etype score ===')
+pprint.pprint(etype_score, width=100)
+print('=== entire score ===')
+print(entire_score)
+"""
+=== etype score ===
+{'M': {'f_0.5': 0.0, 'fn': 1, 'fp': 0, 'p': 1.0, 'r': 0.0, 'tp': 0},
+ 'R': {'f_0.5': 1.0, 'fn': 0, 'fp': 0, 'p': 1.0, 'r': 1.0, 'tp': 2}}
+=== entire score ===
+{'tp': 2, 'fp': 0, 'fn': 1, 'p': 1.0, 'r': 0.6667, 'f_0.5': 0.9091}
+"""
+```
+
+- From edits
+```py
+import errant
+import pprint
+annotator = errant.load('en')
+orig_raw = ['This are gramamtical sentence .']
+cor_raw = ['This is grammatical sentence .']
+# refs_raw: List[List[str]] = (num_annotation, num_sents)
+# This contains two annotations for one sentence
+refs_raw = [
+    ['This is a grammatical sentence .'],
+    ['These are grammatical sentences .']
+]
+orig = [annotator.parse(o) for o in orig_raw]
+cor = [annotator.parse(c) for c in cor_raw]
+refs = [[annotator.parse(r) for r in ref] for ref in refs_raw]
+hyp_edits = [annotator.annotate(o, c) for o, c in zip(orig, cor)]
+ref_edits = [[annotator.annotate(o, r) for o, r in zip(orig, ref)] for ref in refs]
+entire_score, etype_score = errant.compare_from_edits(
+    hyp_edits=hyp_edits,
+    ref_edits=ref_edits,
+    beta=0.5,
+    cat=1,
+    single=False,
+    multi=False,
+    detection=False,
+    cat_filter=[]
+)
+
+print('=== etype score ===')
+pprint.pprint(etype_score, width=100)
+print('=== entire score ===')
+print(entire_score)
+```
+
 ### Alignment Objects
 
 An Alignment object is created from two spacy-parsed text sequences.

--- a/README.md
+++ b/README.md
@@ -200,12 +200,12 @@ overall_score, etype_score = errant.compare_from_raw(
     orig=orig_raw,
     cor=cor_raw,
     refs=refs_raw,
-    beta=0.5,
-    cat=1,
+    beta=0.5,  # beta for F-score
+    cat=1,  # can be 1, 2, 3
     single=False,
     multi=False,
-    detection=False,
-    filt=[]
+    mode='cs',  # can be 'cs', 'ds', 'dt', 'cse'
+    filt=[]  # error type filtering
 )
 
 print('=== etype score ===')
@@ -246,7 +246,7 @@ entire_score, etype_score = errant.compare_from_edits(
     cat=1,
     single=False,
     multi=False,
-    detection=False,
+    mode='cs',
     filt=[]
 )
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,79 @@
+# API-based ERRANT Compare
+
+This forked repository supports API-based errant_compare.
+
+- From raw text
+```py
+import errant
+orig_raw = ['This are gramamtical sentence .']
+cor_raw = ['This is grammatical sentence .']
+# refs_raw: List[List[str]] = (num_annotation, num_sents)
+refs_raw = [
+    ['This is a grammatical sentence .'],
+    ['These are grammatical sentences .']
+]
+output: errant.compare.ERRANTCompareOutput = errant.compare_from_raw(
+    orig=orig_raw,
+    cor=cor_raw,
+    refs=refs_raw,
+    beta=0.5,  # beta for F-score
+    cat=3,  # can be 1, 2, 3
+    single=False,
+    multi=False,
+    mode='cs',  # can be 'cs', 'ds', 'dt', 'cse'
+    filt=[]  # error type filtering
+)
+print('Overall score')
+print(output.overall)  # You can also use output.overall.tp (or .fp .fn .precision .recall .f)
+print('Error type based scores')
+print(output.etype)
+print('Selected reference-id for each input')
+print(output.best_ref_ids)
+
+'''Output
+Overall score
+[TP=2, FP=0, FN=1, Precision=1.0, Recall=0.6666666666666666, F_0.5=0.9090909090909091]
+Error type based scores
+{
+    'R:VERB:SVA': [TP=1, FP=0, FN=0, Precision=1.0, Recall=1.0, F_0.5=1.0],
+    'M:DET': [TP=0, FP=0, FN=1, Precision=1.0, Recall=0.0, F_0.5=0.0],
+    'R:SPELL': [TP=1, FP=0, FN=0, Precision=1.0, Recall=1.0, F_0.5=1.0]
+}
+Selected reference-id for each input
+[0]
+'''
+```
+
+- From edits
+```py
+import errant
+import pprint
+annotator = errant.load('en')
+orig_raw = ['This are gramamtical sentence .']
+cor_raw = ['This is grammatical sentence .']
+# refs_raw: List[List[str]] = (num_annotation, num_sents)
+# This contains two annotations for one sentence
+refs_raw = [
+    ['This is a grammatical sentence .'],
+    ['These are grammatical sentences .']
+]
+orig = [annotator.parse(o) for o in orig_raw]
+cor = [annotator.parse(c) for c in cor_raw]
+refs = [[annotator.parse(r) for r in ref] for ref in refs_raw]
+hyp_edits = [annotator.annotate(o, c) for o, c in zip(orig, cor)]
+ref_edits = [[annotator.annotate(o, r) for o, r in zip(orig, ref)] for ref in refs]
+output: errant.compare.ERRANTCompareOutput = errant.compare_from_edits(
+    hyp_edits=hyp_edits,
+    ref_edits=ref_edits,
+    beta=0.5,
+    cat=3,
+    single=False,
+    multi=False,
+    mode='cs',
+    filt=[]
+)
+```
+
 # ERRANT v3.0.0
 
 This repository contains the grammatical ERRor ANnotation Toolkit (ERRANT) described in:
@@ -179,81 +255,6 @@ cor = annotator.parse('This is a grammatical sentence .')
 edit = [1, 2, 1, 2, 'SVA'] # are -> is
 edit = annotator.import_edit(orig, cor, edit)
 print(edit.to_m2())
-```
-
-### API-based errant_compare
-
-It provides API-based errant_compare.
-
-- From raw text
-```py
-import errant
-import pprint
-orig_raw = ['This are gramamtical sentence .']
-cor_raw = ['This is grammatical sentence .']
-# refs_raw: List[List[str]] = (num_annotation, num_sents)
-refs_raw = [
-    ['This is a grammatical sentence .'],
-    ['These are grammatical sentences .']
-]
-overall_score, etype_score = errant.compare_from_raw(
-    orig=orig_raw,
-    cor=cor_raw,
-    refs=refs_raw,
-    beta=0.5,  # beta for F-score
-    cat=1,  # can be 1, 2, 3
-    single=False,
-    multi=False,
-    mode='cs',  # can be 'cs', 'ds', 'dt', 'cse'
-    filt=[]  # error type filtering
-)
-
-print('=== etype score ===')
-pprint.pprint(etype_score, width=100)
-print('=== overall score ===')
-print(overall_score)
-"""
-=== etype score ===
-{'M': {'f_0.5': 0.0, 'fn': 1, 'fp': 0, 'p': 1.0, 'r': 0.0, 'tp': 0},
- 'R': {'f_0.5': 1.0, 'fn': 0, 'fp': 0, 'p': 1.0, 'r': 1.0, 'tp': 2}}
-=== overall score ===
-{'tp': 2, 'fp': 0, 'fn': 1, 'p': 1.0, 'r': 0.6667, 'f_0.5': 0.9091}
-"""
-```
-
-- From edits
-```py
-import errant
-import pprint
-annotator = errant.load('en')
-orig_raw = ['This are gramamtical sentence .']
-cor_raw = ['This is grammatical sentence .']
-# refs_raw: List[List[str]] = (num_annotation, num_sents)
-# This contains two annotations for one sentence
-refs_raw = [
-    ['This is a grammatical sentence .'],
-    ['These are grammatical sentences .']
-]
-orig = [annotator.parse(o) for o in orig_raw]
-cor = [annotator.parse(c) for c in cor_raw]
-refs = [[annotator.parse(r) for r in ref] for ref in refs_raw]
-hyp_edits = [annotator.annotate(o, c) for o, c in zip(orig, cor)]
-ref_edits = [[annotator.annotate(o, r) for o, r in zip(orig, ref)] for ref in refs]
-entire_score, etype_score = errant.compare_from_edits(
-    hyp_edits=hyp_edits,
-    ref_edits=ref_edits,
-    beta=0.5,
-    cat=1,
-    single=False,
-    multi=False,
-    mode='cs',
-    filt=[]
-)
-
-print('=== etype score ===')
-pprint.pprint(etype_score, width=100)
-print('=== entire score ===')
-print(entire_score)
 ```
 
 ### Alignment Objects

--- a/errant/__init__.py
+++ b/errant/__init__.py
@@ -1,10 +1,28 @@
-from .annotator import Annotator
-from .compare import compare_from_raw, compare_from_edits
-from .edit import Edit
+from importlib import import_module
+import spacy
+from errant.annotator import Annotator
+from errant.compare import compare_from_raw, compare_from_edits
 
 # ERRANT version
 __version__ = '3.0.0'
 
 # Load an ERRANT Annotator object for a given language
 def load(lang, nlp=None):
-    return Annotator.load(lang, nlp)
+        # Make sure the language is supported
+    supported = {"en"}
+    if lang not in supported:
+        raise Exception(f"{lang} is an unsupported or unknown language")
+
+    # Load spacy (small model if no model supplied)
+    nlp = nlp or spacy.load(f"{lang}_core_web_sm", disable=["ner"])
+
+    # Load language edit merger
+    merger = import_module(f"errant.{lang}.merger")
+
+    # Load language edit classifier
+    classifier = import_module(f"errant.{lang}.classifier")
+    # The English classifier needs spacy
+    if lang == "en": classifier.nlp = nlp
+
+    # Return a configured ERRANT annotator
+    return Annotator(lang, nlp, merger, classifier)

--- a/errant/__init__.py
+++ b/errant/__init__.py
@@ -1,27 +1,10 @@
-from importlib import import_module
-import spacy
-from errant.annotator import Annotator
+from .annotator import Annotator
+from .compare import compare_from_raw, compare_from_edits
+from .edit import Edit
 
 # ERRANT version
 __version__ = '3.0.0'
 
 # Load an ERRANT Annotator object for a given language
 def load(lang, nlp=None):
-    # Make sure the language is supported
-    supported = {"en"}
-    if lang not in supported:
-        raise Exception(f"{lang} is an unsupported or unknown language")
-
-    # Load spacy (small model if no model supplied)
-    nlp = nlp or spacy.load(f"{lang}_core_web_sm", disable=["ner"])
-
-    # Load language edit merger
-    merger = import_module(f"errant.{lang}.merger")
-
-    # Load language edit classifier
-    classifier = import_module(f"errant.{lang}.classifier")
-    # The English classifier needs spacy
-    if lang == "en": classifier.nlp = nlp
-
-    # Return a configured ERRANT annotator
-    return Annotator(lang, nlp, merger, classifier)
+    return Annotator.load(lang, nlp)

--- a/errant/compare.py
+++ b/errant/compare.py
@@ -1,0 +1,266 @@
+from .annotator import Annotator
+from .edit import Edit
+from typing import List
+import copy
+import pprint
+
+def check_num_sents(
+    srcs,
+    hyps,
+    refs
+):
+    for r in refs:
+        assert len(r) == len(srcs) 
+        assert len(r) == len(hyps)
+    return
+
+def compare_from_raw(
+    orig: List[str],
+    cor: List[str],
+    refs: List[List[str]],
+    beta=0.5,
+    cat=1,
+    detection=False, # correction is default
+    single=False,
+    multi=False,
+    cat_filter=[],
+    verbose=False
+):
+    # The references must be a two dimensions list
+    if not isinstance(refs[0], list):
+        refs = [refs]
+    check_num_sents(
+        orig, cor, refs
+    )
+    annotator = Annotator.load('en')
+    parsed_s = []
+    for s in orig:
+        s = annotator.parse(s)
+        parsed_s.append(s)
+    # parsed_s = [annotator.parse(s) for s in sources]
+    hyp_edits: List[List[Edit]] = []
+    for i, h in enumerate(cor):
+        parsed_h = annotator.parse(h)
+        edits = annotator.annotate(parsed_s[i], parsed_h)
+        hyp_edits.append(edits)
+    ref_edits: List[List[List[Edit]]] = []  # (num_refs, num_sents, num_edits)
+    for ref in refs:
+        ref_ith_edits = []
+        for i, r in enumerate(ref):
+            parsed_r = annotator.parse(r)
+            edits = annotator.annotate(parsed_s[i], parsed_r)
+            ref_ith_edits.append(edits)
+        ref_edits.append(ref_ith_edits)
+    entire_score, etype_score = compare_from_edits(
+        hyp_edits,
+        ref_edits,
+        beta=beta,
+        cat=cat,
+        detection=detection,
+        single=single,
+        multi=multi,
+        cat_filter=cat_filter,
+        verbose=verbose
+    )
+    return entire_score, etype_score
+
+def compute_f(tp, fp, fn, beta):
+    p = float(tp)/(tp+fp) if fp else 1.0
+    r = float(tp)/(tp+fn) if fn else 1.0
+    f = float((1+(beta**2))*p*r)/(((beta**2)*p)+r) if p+r else 0.0
+    return round(p, 4), round(r, 4), round(f, 4)
+
+def can_update_best(current_score, new_score, beta=0.5):
+    current_entire_score = calc_entire_score(current_score)
+    new_entire_score = calc_entire_score(new_score)
+    cp, cr, cf = compute_f(
+        current_entire_score['tp'],
+        current_entire_score['fp'],
+        current_entire_score['fn'],
+        beta
+    )
+    np, nr, nf = compute_f(
+        new_entire_score['tp'],
+        new_entire_score['fp'],
+        new_entire_score['fn'],
+        beta
+    )
+    # if nf > cf or \
+    #     (nf == cf and new_score['tp'] > current_score['tp']) or \
+    #     (nf == cf and new_score['tp'] == current_score['tp'] and \
+    #         new_score['fp'] < current_score['fp']) or \
+    #     (nf == cf and new_score['tp'] == current_score['tp'] and \
+    #         new_score['fp'] == current_score['fp'] and \
+    #         new_score['fn'] < current_score['fn']):
+    #     return True
+    if nf > cf:
+        return True
+    if nf == cf and new_entire_score['tp'] > current_entire_score['tp']:
+        return True
+    if nf == cf and new_entire_score['tp'] == current_entire_score['tp'] \
+        and new_entire_score['fp'] < current_entire_score['fp']:
+        return True
+    if nf == cf and new_entire_score['tp'] == current_entire_score['tp'] \
+        and new_entire_score['fp'] == current_entire_score['fp'] \
+        and new_entire_score['fn'] < current_entire_score['fn']:
+        return True
+    return False
+
+def filter_edits(
+    edits: List[List[Edit]],
+    cat=1,
+    detection=False, # correction is default
+    single=False,
+    multi=False,
+    cat_filter=[],
+):
+    assert not (single and multi)
+    new_edits = []
+    for edit in edits:
+        l = []
+        for e in edit:
+            if e.o_start == -1:
+                continue
+            if e.type in cat_filter:
+                continue
+            if single and e.is_multi():
+                continue
+            if multi and e.is_single():
+                continue
+            if detection:
+                e.c_str = ''
+            elif e.type in ['UNK']:
+                # UNK is treated for only detection
+                continue
+            if cat == 1:
+                e.type = e.type[0]
+            elif cat == 2:
+                e.type = e.type[2:]
+            l.append(e)
+        new_edits.append(l)
+    return new_edits
+    
+def calc_entire_score(score):
+    '''Convert error type based scores into an entire score.
+    '''
+    entire_score = {'tp': 0, 'fp': 0, 'fn': 0}
+    for etype in score:
+        for k in ['tp', 'fp', 'fn']:
+            entire_score[k] += score[etype][k]
+    return entire_score
+
+def merge_dict(d1, d2):
+    '''Add d2 information to d1
+    '''
+    if d1 is None:
+        return d2
+    for etype in d2.keys():
+        d1[etype] = d1.get(etype, {'tp': 0, 'fp': 0, 'fn': 0})
+        for k in ['tp', 'fp', 'fn']:
+            d1[etype][k] += d2[etype][k]
+    return d1
+
+def print_table(table):
+    longest_cols = [
+        (max([len(str(row[i])) for row in table]) + 3)
+        for i in range(len(table[0]))
+    ]
+    row_format = "".join(["{:>" + str(longest_col) + "}" for longest_col in longest_cols])
+    for row in table:
+        print(row_format.format(*row))
+
+def compare_from_edits(
+    hyp_edits: List[List[Edit]],
+    ref_edits: List[List[List[Edit]]],
+    beta=0.5,
+    cat=1,
+    detection=False, # correction is default
+    single=False,
+    multi=False,
+    cat_filter=[],
+    verbose=False
+):
+    if not isinstance(hyp_edits[0], list):
+        hyp_edits = [hyp_edits]
+    filter_args = {
+        'cat': cat,
+        'detection': detection,
+        'single': single,
+        'multi': multi,
+        'cat_filter': cat_filter
+    }
+    # Removed correction to not be evaluated according to the setting
+    hyp_edits = filter_edits(hyp_edits, **filter_args)
+    ref_edits = [filter_edits(r, **filter_args) for r in ref_edits]
+    for ref_id in range(len(ref_edits)):
+        assert len(hyp_edits) == len(ref_edits[ref_id])
+    etype_score = None
+    # The shape of ref_edits is (num_refs, num_sents, num_edits)
+    num_sents = len(ref_edits[0])
+    num_annotator = len(ref_edits)
+    for sent_id in range(num_sents):
+        # best_score: sentence-level best score
+        # shape: best_score[error_type]['tp'|'fp'|'fn'] = int
+        best_score = None
+        best_ref = 0
+        for ref_id in range(num_annotator):
+            current_score = dict()
+            h_edits = hyp_edits[sent_id]
+            r_edits = ref_edits[ref_id][sent_id]
+            # True positive and False positive
+            for edit in r_edits:
+                current_score[edit.type] = current_score.get(
+                    edit.type,
+                    {'tp': 0, 'fp': 0, 'fn': 0}
+                )
+                if edit in h_edits:
+                    current_score[edit.type]['tp'] += 1
+                else:
+                    current_score[edit.type]['fn'] += 1
+            # False negative
+            for edit in h_edits:
+                if edit not in r_edits:
+                    current_score[edit.type] = current_score.get(
+                        edit.type,
+                        {'tp': 0, 'fp': 0, 'fn': 0}
+                    )
+                    current_score[edit.type]['fp'] += 1
+            # Update the best sentence-level score
+            if best_score is None:
+                # For the first refernece
+                best_score = current_score
+            elif can_update_best(
+                merge_dict(copy.deepcopy(etype_score), best_score),
+                merge_dict(copy.deepcopy(etype_score), current_score),
+                beta
+            ):
+                # For the second or subsequent reference, chose the best one
+                best_score = current_score
+                best_ref = ref_id
+        if verbose:
+            print('{:-^40}'.format(""))
+            print(f'^^ HYP 0, REF {best_ref} chosen for sentence {sent_id}')
+            print('Local results:')
+            header = ["Category", "TP", "FP", "FN"]
+            body = [[k, v['tp'], v['fp'], v['fn']] for k, v in best_score.items()]
+            print_table([header] + body)
+        # print(f'=== Sent {sent_id} ===')
+        # print(calc_entire_score(best_score))
+        # Add to the best sentence-level score to the overall scores
+        etype_score = merge_dict(etype_score, best_score)
+    # print(etype_score)
+    for etype in etype_score.keys():
+        etype_score[etype]['p'], etype_score[etype]['r'], etype_score[etype][f'f_{beta}'] = compute_f(
+            etype_score[etype]['tp'],
+            etype_score[etype]['fp'],
+            etype_score[etype]['fn'],
+            beta
+        )
+    entire_score = calc_entire_score(etype_score)
+    entire_score['p'], entire_score['r'], entire_score[f'f_{beta}'] = compute_f(
+        entire_score['tp'],
+        entire_score['fp'],
+        entire_score['fn'],
+        beta
+    )
+    return entire_score, etype_score

--- a/errant/compare.py
+++ b/errant/compare.py
@@ -1,14 +1,15 @@
-from .annotator import Annotator
-from .edit import Edit
+from errant.edit import Edit
 from typing import List
 import copy
 import pprint
+from typing import List, Tuple, Union, Dict
+import errant
 
 def check_num_sents(
-    srcs,
-    hyps,
-    refs
-):
+    srcs: List[str],
+    hyps: List[str],
+    refs: List[List[str]]
+) -> None:
     for r in refs:
         assert len(r) == len(srcs) 
         assert len(r) == len(hyps)
@@ -18,40 +19,75 @@ def compare_from_raw(
     orig: List[str],
     cor: List[str],
     refs: List[List[str]],
-    beta=0.5,
-    cat=1,
-    detection=False, # correction is default
-    single=False,
-    multi=False,
-    cat_filter=[],
-    verbose=False
-):
+    beta: float=0.5,
+    cat: int=1,
+    detection: bool=False, # correction is default
+    single: bool=False,
+    multi: bool=False,
+    filt: List[str]=[],
+    verbose: bool=False
+) -> Tuple[
+        Dict[str, Union[int, float]],
+        Dict[str, Dict[str, Union[int, float]]]
+    ]:
+    '''errant_compare given the raw text
+    Args:
+        orig: Original sentences
+        cor: Corrected sentences
+        refs: References
+            refs can be multiple. The shape is (num_annotations, num_sents)
+        beta: the beta for F_{beta}
+        cat: 1 or 2 or 3.
+            1: Only show operation tier scores; e.g. R.
+            2: Only show main tier scores; e.g. NOUN.
+            3: Show all category scores; e.g. R:NOUN.
+        detection: To calculate detection score.
+        single: Only evaluate single token edits; i.e. 0:1, 1:0 or 1:1
+        mulit: Only evaluate multi token edits; i.e. 2+:n or n:2+
+        filt: Do not evaluate the specified error types.
+        verbose: Print verbose output.
+    Returns:
+        overall_score: The key is {'tp', 'fp', 'fn', 'p', 'r', 'f_{beta}'}.
+        etype_score: Error-type-wise score. 
+            This is two dimensional dictionaly.
+            The first key is error type.
+            The second key is {'tp', 'fp', 'fn', 'p', 'r', 'f_{beta}'}.
+            The values is the number of corrections.
+    '''
     # The references must be a two dimensions list
     if not isinstance(refs[0], list):
+        # The shape of refs must be (num_annotations, num_sents)
         refs = [refs]
     check_num_sents(
         orig, cor, refs
     )
-    annotator = Annotator.load('en')
-    parsed_s = []
-    for s in orig:
-        s = annotator.parse(s)
-        parsed_s.append(s)
-    # parsed_s = [annotator.parse(s) for s in sources]
-    hyp_edits: List[List[Edit]] = []
-    for i, h in enumerate(cor):
-        parsed_h = annotator.parse(h)
-        edits = annotator.annotate(parsed_s[i], parsed_h)
-        hyp_edits.append(edits)
-    ref_edits: List[List[List[Edit]]] = []  # (num_refs, num_sents, num_edits)
-    for ref in refs:
-        ref_ith_edits = []
-        for i, r in enumerate(ref):
-            parsed_r = annotator.parse(r)
-            edits = annotator.annotate(parsed_s[i], parsed_r)
-            ref_ith_edits.append(edits)
-        ref_edits.append(ref_ith_edits)
-    entire_score, etype_score = compare_from_edits(
+    annotator = errant.load('en')
+    # parsed_s = []
+    # for s in orig:
+    #     s = annotator.parse(s)
+    #     parsed_s.append(s)
+    # # parsed_s = [annotator.parse(s) for s in sources]
+    # hyp_edits: List[List[Edit]] = []
+    # for i, h in enumerate(cor):
+    #     parsed_h = annotator.parse(h)
+    #     edits = annotator.annotate(parsed_s[i], parsed_h)
+    #     hyp_edits.append(edits)
+    # ref_edits: List[List[List[Edit]]] = []  # (num_refs, num_sents, num_edits)
+    # for ref in refs:
+    #     ref_ith_edits = []
+    #     for i, r in enumerate(ref):
+    #         parsed_r = annotator.parse(r)
+    #         edits = annotator.annotate(parsed_s[i], parsed_r)
+    #         ref_ith_edits.append(edits)
+    #     ref_edits.append(ref_ith_edits)
+    # Parse each sentences
+    orig = [annotator.parse(o) for o in orig]
+    cor = [annotator.parse(c) for c in cor]
+    refs = [[annotator.parse(r) for r in ref] for ref in refs]
+    # Generate Edit objects
+    hyp_edits = [annotator.annotate(o, c) for o, c in zip(orig, cor)]
+    ref_edits = [[annotator.annotate(o, r) for o, r in zip(orig, ref)] for ref in refs]
+    overall_score, etype_score = compare_from_edits(
         hyp_edits,
         ref_edits,
         beta=beta,
@@ -59,97 +95,118 @@ def compare_from_raw(
         detection=detection,
         single=single,
         multi=multi,
-        cat_filter=cat_filter,
+        filt=filt,
         verbose=verbose
     )
-    return entire_score, etype_score
+    return overall_score, etype_score
 
-def compute_f(tp, fp, fn, beta):
+def compute_f(tp: int, fp: int, fn: int, beta: float):
+    '''Compute F_{beta} score given TP, FP, FN.
+    This is copied from official imlementation:
+        https://github.com/chrisjbryant/errant
+    '''
     p = float(tp)/(tp+fp) if fp else 1.0
     r = float(tp)/(tp+fn) if fn else 1.0
     f = float((1+(beta**2))*p*r)/(((beta**2)*p)+r) if p+r else 0.0
     return round(p, 4), round(r, 4), round(f, 4)
 
-def can_update_best(current_score, new_score, beta=0.5):
-    current_entire_score = calc_entire_score(current_score)
-    new_entire_score = calc_entire_score(new_score)
+def can_update_best(
+    current_score: Dict[str, Dict[str, Union[int, float]]],
+    new_score: Dict[str, Dict[str, Union[int, float]]],
+    beta: float=0.5
+):
+    '''Check whether the new_score outperforms the current best score.
+    '''
+    # The inputs are error-type-wise scores, so we first convert them to entire score
+    current_overall_score = calc_overall_score(current_score)
+    new_overall_score = calc_overall_score(new_score)
+    # Compute F_{beta} given TP/FP/FN
     cp, cr, cf = compute_f(
-        current_entire_score['tp'],
-        current_entire_score['fp'],
-        current_entire_score['fn'],
+        current_overall_score['tp'],
+        current_overall_score['fp'],
+        current_overall_score['fn'],
         beta
     )
     np, nr, nf = compute_f(
-        new_entire_score['tp'],
-        new_entire_score['fp'],
-        new_entire_score['fn'],
+        new_overall_score['tp'],
+        new_overall_score['fp'],
+        new_overall_score['fn'],
         beta
     )
-    # if nf > cf or \
-    #     (nf == cf and new_score['tp'] > current_score['tp']) or \
-    #     (nf == cf and new_score['tp'] == current_score['tp'] and \
-    #         new_score['fp'] < current_score['fp']) or \
-    #     (nf == cf and new_score['tp'] == current_score['tp'] and \
-    #         new_score['fp'] == current_score['fp'] and \
-    #         new_score['fn'] < current_score['fn']):
-    #     return True
+    # This rule is the same as original implementation.
     if nf > cf:
         return True
-    if nf == cf and new_entire_score['tp'] > current_entire_score['tp']:
+    if nf == cf and new_overall_score['tp'] > current_overall_score['tp']:
         return True
-    if nf == cf and new_entire_score['tp'] == current_entire_score['tp'] \
-        and new_entire_score['fp'] < current_entire_score['fp']:
+    if nf == cf and new_overall_score['tp'] == current_overall_score['tp'] \
+        and new_overall_score['fp'] < current_overall_score['fp']:
         return True
-    if nf == cf and new_entire_score['tp'] == current_entire_score['tp'] \
-        and new_entire_score['fp'] == current_entire_score['fp'] \
-        and new_entire_score['fn'] < current_entire_score['fn']:
+    if nf == cf and new_overall_score['tp'] == current_overall_score['tp'] \
+        and new_overall_score['fp'] == current_overall_score['fp'] \
+        and new_overall_score['fn'] < current_overall_score['fn']:
         return True
     return False
 
 def filter_edits(
     edits: List[List[Edit]],
-    cat=1,
-    detection=False, # correction is default
-    single=False,
-    multi=False,
-    cat_filter=[],
+    cat: int=1,
+    detection: bool=False, # correction is default
+    single: bool=False,
+    multi: bool=False,
+    filt: list=[],
 ):
+    '''To remove the corrections that not to be evaluated.
+    '''
     assert not (single and multi)
     new_edits = []
     for edit in edits:
         l = []
         for e in edit:
+            # 'noop' edits are ignored
             if e.o_start == -1:
                 continue
-            if e.type in cat_filter:
+            # Filtered error types are ignored
+            if e.type in filt:
                 continue
             if single and e.is_multi():
                 continue
             if multi and e.is_single():
-                continue
+                continue 
             if detection:
+                # To ignore c_str in the detection scoring,
+                #   it is replaced with an empty string.
                 e.c_str = ''
             elif e.type in ['UNK']:
                 # UNK is treated for only detection
                 continue
             if cat == 1:
+                # e.g. 'M:NOUN:NUM' -> 'M'
                 e.type = e.type[0]
             elif cat == 2:
+                # e.g. 'M:NOUN:NUM' -> 'NOUN:NUM'
                 e.type = e.type[2:]
             l.append(e)
         new_edits.append(l)
     return new_edits
     
-def calc_entire_score(score):
+def calc_overall_score(score: Dict[str, Dict[str, int]]) -> Dict[str, int]:
     '''Convert error type based scores into an entire score.
+    Args:
+        score: Dict[str, Dict[str, int]]
+            The first key is error type.
+            The second key is 'tp' or 'fp' or 'fn'.
+            The values is the number of corrections.
     '''
-    entire_score = {'tp': 0, 'fp': 0, 'fn': 0}
+    overall_score = {'tp': 0, 'fp': 0, 'fn': 0}
     for etype in score:
         for k in ['tp', 'fp', 'fn']:
-            entire_score[k] += score[etype][k]
-    return entire_score
+            overall_score[k] += score[etype][k]
+    return overall_score
 
-def merge_dict(d1, d2):
+def merge_dict(
+    d1: Dict[str, Dict[str, int]],
+    d2: Dict[str, Dict[str, int]]
+):
     '''Add d2 information to d1
     '''
     if d1 is None:
@@ -161,6 +218,10 @@ def merge_dict(d1, d2):
     return d1
 
 def print_table(table):
+    '''This is for verbose setting.
+    This is copied from official imlementation:
+        https://github.com/chrisjbryant/errant
+    '''
     longest_cols = [
         (max([len(str(row[i])) for row in table]) + 3)
         for i in range(len(table[0]))
@@ -170,44 +231,47 @@ def print_table(table):
         print(row_format.format(*row))
 
 def compare_from_edits(
-    hyp_edits: List[List[Edit]],
-    ref_edits: List[List[List[Edit]]],
-    beta=0.5,
-    cat=1,
-    detection=False, # correction is default
-    single=False,
-    multi=False,
-    cat_filter=[],
-    verbose=False
+    hyp_edits: List[List[Edit]],  # (num_sents, num_edits)
+    ref_edits: List[List[List[Edit]]],  # (num_annotations, num_sents, num_edts)
+    beta: float=0.5,
+    cat: int=1,
+    detection: bool=False, # correction is default
+    single: bool=False,
+    multi: bool=False,
+    filt: List[str]=[],
+    verbose: bool=False
 ):
-    if not isinstance(hyp_edits[0], list):
-        hyp_edits = [hyp_edits]
+    '''errant_compare given edits, which are the results of errant.Annotator.annotate()
+    Args:
+        hyp_edits: The edits between original and correction.
+        ref_edits: The edits between original and references.
+            This can be multiple. The shape is (num_annotations, num_sents, num_edits)
+    Other args and returns is the same as compare_from_raw().
+    '''
     filter_args = {
         'cat': cat,
         'detection': detection,
         'single': single,
         'multi': multi,
-        'cat_filter': cat_filter
+        'filt': filt
     }
-    # Removed correction to not be evaluated according to the setting
+    # Removed correction not to be evaluated
     hyp_edits = filter_edits(hyp_edits, **filter_args)
     ref_edits = [filter_edits(r, **filter_args) for r in ref_edits]
     for ref_id in range(len(ref_edits)):
         assert len(hyp_edits) == len(ref_edits[ref_id])
-    etype_score = None
-    # The shape of ref_edits is (num_refs, num_sents, num_edits)
-    num_sents = len(ref_edits[0])
+    etype_score = None  # This will be final scores
     num_annotator = len(ref_edits)
+    num_sents = len(ref_edits[0])
     for sent_id in range(num_sents):
         # best_score: sentence-level best score
-        # shape: best_score[error_type]['tp'|'fp'|'fn'] = int
-        best_score = None
+        best_score: Dict[str, Dict[str, int]] = None
         best_ref = 0
         for ref_id in range(num_annotator):
             current_score = dict()
             h_edits = hyp_edits[sent_id]
             r_edits = ref_edits[ref_id][sent_id]
-            # True positive and False positive
+            # True positive and False negative
             for edit in r_edits:
                 current_score[edit.type] = current_score.get(
                     edit.type,
@@ -217,7 +281,7 @@ def compare_from_edits(
                     current_score[edit.type]['tp'] += 1
                 else:
                     current_score[edit.type]['fn'] += 1
-            # False negative
+            # False positive
             for edit in h_edits:
                 if edit not in r_edits:
                     current_score[edit.type] = current_score.get(
@@ -227,7 +291,6 @@ def compare_from_edits(
                     current_score[edit.type]['fp'] += 1
             # Update the best sentence-level score
             if best_score is None:
-                # For the first refernece
                 best_score = current_score
             elif can_update_best(
                 merge_dict(copy.deepcopy(etype_score), best_score),
@@ -235,6 +298,7 @@ def compare_from_edits(
                 beta
             ):
                 # For the second or subsequent reference, chose the best one
+                # Note that the comparison is based on the value when added to the cumulative score so far
                 best_score = current_score
                 best_ref = ref_id
         if verbose:
@@ -244,11 +308,9 @@ def compare_from_edits(
             header = ["Category", "TP", "FP", "FN"]
             body = [[k, v['tp'], v['fp'], v['fn']] for k, v in best_score.items()]
             print_table([header] + body)
-        # print(f'=== Sent {sent_id} ===')
-        # print(calc_entire_score(best_score))
-        # Add to the best sentence-level score to the overall scores
+        # Add to the best sentence-level score to the overall score
         etype_score = merge_dict(etype_score, best_score)
-    # print(etype_score)
+    # Calculate precision, recall, F_{beta} for each error type
     for etype in etype_score.keys():
         etype_score[etype]['p'], etype_score[etype]['r'], etype_score[etype][f'f_{beta}'] = compute_f(
             etype_score[etype]['tp'],
@@ -256,11 +318,13 @@ def compare_from_edits(
             etype_score[etype]['fn'],
             beta
         )
-    entire_score = calc_entire_score(etype_score)
-    entire_score['p'], entire_score['r'], entire_score[f'f_{beta}'] = compute_f(
-        entire_score['tp'],
-        entire_score['fp'],
-        entire_score['fn'],
+    # Calculate overall score from error type wise score
+    overall_score = calc_overall_score(etype_score)
+    # And precision, recall and F_{beta}
+    overall_score['p'], overall_score['r'], overall_score[f'f_{beta}'] = compute_f(
+        overall_score['tp'],
+        overall_score['fp'],
+        overall_score['fn'],
         beta
     )
-    return entire_score, etype_score
+    return overall_score, etype_score

--- a/errant/compare.py
+++ b/errant/compare.py
@@ -5,7 +5,6 @@ import pprint
 from typing import List, Tuple, Union, Dict
 import errant
 from dataclasses import dataclass, field
-from tabulate import tabulate
 
 class Score:
     def __init__(

--- a/errant/edit.py
+++ b/errant/edit.py
@@ -56,9 +56,6 @@ class Edit:
         return ", ".join([orig, cor, type])
     
     def __eq__(self, other):
-        # print(self.o_start == other.o_start)
-        # print(self.o_end == other.o_end)
-        # print(self.c_str == other.c_str)
         return isinstance(other, Edit) \
             and self.o_start == other.o_start \
             and self.o_end == other.o_end \

--- a/errant/edit.py
+++ b/errant/edit.py
@@ -54,3 +54,22 @@ class Edit:
         cor = "Cor: "+str([self.c_start, self.c_end, self.c_str])
         type = "Type: "+repr(self.type)
         return ", ".join([orig, cor, type])
+    
+    def __eq__(self, other):
+        # print(self.o_start == other.o_start)
+        # print(self.o_end == other.o_end)
+        # print(self.c_str == other.c_str)
+        return isinstance(other, Edit) \
+            and self.o_start == other.o_start \
+            and self.o_end == other.o_end \
+            and self.c_str == other.c_str \
+            # and self.type == other.type
+    
+    def __ne__(self, other):
+        return not self.__eq__(other)
+        
+    def is_single(self):
+        return max(len(self.o_str.split()), len(self.c_str.split())) <= 1
+    
+    def is_multi(self):
+        return not self.is_single()


### PR DESCRIPTION
Hi, as can be seen in the issue https://github.com/chrisjbryant/errant/issues/25, I think API-based errant_compare feature will be useful for many people.
I also want the feature so I created a pilot version.
Mainly, 
- Overall, the implementation does not use coder_dict, but uses the Edit object directly.
- Created errant/compare.py and implement the API-based errant_compare
- Added `__eq__()` function to the Edit class to compare two objects easily.
- All of options used in the official are supported (i.e. -cs, -ds, -dt, -cse, -single, -multi, -cat and -filt)

Using the GEC system's correction results at hand, I confirmed that the results of the official implementation match the results of my implementation.

I do not think this PR will be merged as is, but I hope this is a clue to development of API-based errant_compare!