### PR TITLE
Alpha support for German

### DIFF
--- a/errant/__init__.py
+++ b/errant/__init__.py
@@ -8,7 +8,7 @@ __version__ = '3.0.0'
 # Load an ERRANT Annotator object for a given language
 def load(lang, nlp=None):
     # Make sure the language is supported
-    supported = {"en"}
+    supported = {"de", "en"}
     if lang not in supported:
         raise Exception(f"{lang} is an unsupported or unknown language")
 
@@ -16,12 +16,14 @@ def load(lang, nlp=None):
     nlp = nlp or spacy.load(f"{lang}_core_web_sm", disable=["ner"])
 
     # Load language edit merger
-    merger = import_module(f"errant.{lang}.merger")
+    if lang != "en":
+        print(f"WARNING: Loading English merger and classifier for language {lang}")
+    merger = import_module(f"errant.en.merger")
 
     # Load language edit classifier
-    classifier = import_module(f"errant.{lang}.classifier")
+    classifier = import_module(f"errant.en.classifier")
     # The English classifier needs spacy
-    if lang == "en": classifier.nlp = nlp
+    classifier.nlp = nlp
 
     # Return a configured ERRANT annotator
     return Annotator(lang, nlp, merger, classifier)

--- a/errant/__init__.py
+++ b/errant/__init__.py
@@ -11,9 +11,13 @@ def load(lang, nlp=None):
     supported = {"de", "en"}
     if lang not in supported:
         raise Exception(f"{lang} is an unsupported or unknown language")
+    elif lang == "en":
+        spacy_small = "en_core_web_sm"
+    elif lang == "de":
+        spacy_small = "de_core_news_sm"
 
     # Load spacy (small model if no model supplied)
-    nlp = nlp or spacy.load(f"{lang}_core_web_sm", disable=["ner"])
+    nlp = nlp or spacy.load(spacy_small, disable=["ner"])
 
     # Load language edit merger
     if lang != "en":

--- a/errant/commands/parallel_to_m2.py
+++ b/errant/commands/parallel_to_m2.py
@@ -7,7 +7,7 @@ def main():
     args = parse_args()
     print("Loading resources...")
     # Load Errant
-    annotator = errant.load("en")
+    annotator = errant.load(args.lang)
 
     print("Processing parallel files...")
     # Process an arbitrary number of files line by line simultaneously. Python 3.3+
@@ -64,6 +64,13 @@ def parse_args():
         "-out", 
         help="The output filepath.",
         required=True)
+    parser.add_argument(
+        "-lang", 
+        help="The language you are working with, loads the appropriate spacy model.\n"
+            "en: English (default)\n"
+            "de: German",
+        choices=["en", "de"],
+        default="en")
     parser.add_argument(
         "-tok", 
         help="Word tokenise the text using spacy (default: False).",


### PR DESCRIPTION
Hi Chris!

* add "lang" = language to argparse, with "en" the default.
* Enables multilingual use of ERRANT.
* Prompted by "MultiGEC" shared task for NLP4CALL 2025 ; will add more language options if you approve the idea

best, Andrew