### PR TITLE
Fix Lancaster regex escape warnings

### DIFF
--- a/errant/en/lancaster.py
+++ b/errant/en/lancaster.py
@@ -189,7 +189,7 @@ class LancasterStemmer:
         """
         # If there is no argument for the function, use class' own rule tuple.
         rule_tuple = rule_tuple if rule_tuple else self._rule_tuple
-        valid_rule = re.compile("^[a-z]+\*?\d[a-z]*[>\.]?$")
+        valid_rule = re.compile(r"^[a-z]+\*?\d[a-z]*[>\.]?$")
         # Empty any old rules from the rule set before adding new ones
         self.rule_dictionary = {}
 
@@ -222,7 +222,7 @@ class LancasterStemmer:
         """Perform the actual word stemming
         """
 
-        valid_rule = re.compile("^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$")
+        valid_rule = re.compile(r"^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$")
 
         proceed = True
 


### PR DESCRIPTION
## Summary

- Convert the Lancaster stemmer rule-validation regex strings to raw strings.
- Preserve the existing regular expressions while avoiding Python SyntaxWarning messages for invalid escape sequences.

Fixes #55.

## Validation

- `git diff --check HEAD~1..HEAD`

Not run locally.